### PR TITLE
Remove ignored parameter

### DIFF
--- a/src/timeago.js
+++ b/src/timeago.js
@@ -38,7 +38,7 @@ function () {
   function toDate(input) {
     if (input instanceof Date) return input;
     if (!isNaN(input)) return new Date(toInt(input));
-    if (/^\d+$/.test(input)) return new Date(toInt(input, 10));
+    if (/^\d+$/.test(input)) return new Date(toInt(input));
     input = (input || '').trim().replace(/\.\d+/, '') // remove milliseconds
       .replace(/-/, '/').replace(/-/, '/')
       .replace(/T/, ' ').replace(/Z/, ' UTC')


### PR DESCRIPTION
For my thesis on type systems in JavaScript, I used your project as one of the testcases. During the research, I found two issues. One of them was already reported and fixed (#88), for the other I created this PR. `toInt` accepts only one argument, whereas it gets two in `toInt(input, 10)`. Can this parameter be ignored or should it be passed to `parseInt`?